### PR TITLE
fix: sometimes cancelled status contains an id

### DIFF
--- a/coman/src/cscs/api_client/types.rs
+++ b/coman/src/cscs/api_client/types.rs
@@ -142,7 +142,7 @@ pub enum JobStatus {
 }
 impl From<String> for JobStatus {
     fn from(value: String) -> Self {
-        match value.as_str() {
+        match value.split_whitespace().next().unwrap() {
             "RUNNING" => JobStatus::Running,
             "FAILED" => JobStatus::Failed,
             "COMPLETED" => JobStatus::Finished,


### PR DESCRIPTION
this fixes when the status is `CANCELLED by 123456` instead of `CANCELLED`